### PR TITLE
Create a custom user

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You can read more about the context here: https://jessboctor.com/2025/06/12/maki
 # The to-do list
 - [x] Create custom user roles
 - [x] Create custom user profile fields
-- [ ] Make it possible to save the user metadata
+- [x] Make it possible to save the user metadata
 - [ ] Create custom user taxonomies
 - [ ] Query the user tables for the group member data
 - [ ] Display the user information in a DataView list

--- a/class.scud-user-role.php
+++ b/class.scud-user-role.php
@@ -25,6 +25,18 @@ class Scud_User {
     ];
 
     /**
+     * An array containing the slug and label for meta-data fields which should be saved to these types of user
+     * The slug and label should be saved as key => value pairs:
+     * [
+     *    'meta_slug' => 'meta_label',
+     * ]
+     */
+    private array $meta_fields = [
+        'slug_1' => 'Slug 1',
+        'slug_2' => 'Slug 2',
+    ];
+
+    /**
      * Register the custom user role
      * Fires only on the activation hook, so the role is only registered once
      *
@@ -61,8 +73,6 @@ class Scud_User {
      * @return void The HTML code to disply the user field
      */
     public function display_user_profile_fields( WP_User $user ): void {
-        // Before we display the profile fields, retrieve the fields from the WP_User object
-        $saved_title = $user->get( 'scud_user_title' );
 
         // For some reason, the action hooks expect the HTML code directly and won't render a string of HTML code
         // It would be cleaner to return the HTML string, but this type of templating works too
@@ -70,12 +80,17 @@ class Scud_User {
         <h3><?php _e('Additional information'); ?></h3>
 
         <table class="form-table">
-            <tr>
-                <th><label for="scud_user_title"><?php _e( 'Title' ); ?></label></th>
-                <td>
-                    <input type="text" name="scud_user_title" id="scud_user_title" value="<?php echo esc_attr( $saved_title ); ?>" />
-                </td>
-            </tr>
+            <?php foreach ( $this->meta_fields as $field_slug => $field_label ):
+                 // Before we display the profile fields, retrieve the fields from the WP_User object
+                 $saved_meta = $user->get( 'scud_user_' . $field_slug );
+                ?>
+                    <tr>
+                        <th><label for="scud_user_<?php echo $field_slug; ?>"><?php echo $field_label; ?></label></th>
+                        <td>
+                            <input type="text" name="scud_user_<?php echo $field_slug; ?>" id="scud_user_<?php echo $field_slug; ?>" value="<?php echo esc_attr( $saved_meta ); ?>" />
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
         </table>
     <?php
     }
@@ -87,14 +102,23 @@ class Scud_User {
      * @return void;
      */
     public function save_user_profile_fields( string $user_id ): void {
-    if ( empty( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'update-user_' . $user_id ) ) {
-        return;
+        if ( empty( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'update-user_' . $user_id ) ) {
+            return;
+        }
+
+        if ( !current_user_can( 'edit_user', $user_id ) ) {
+            return;
+        }
+
+        $fields_not_in_post = [];
+        foreach ( $this->meta_fields as $field_slug => $field_label ) {
+            if ( array_key_exists( 'scud_user_' . $field_slug, $_POST ) ) {
+                update_user_meta( $user_id, 'scud_user_' . $field_slug, $_POST['scud_user_' . $field_slug ] );
+            } else {
+                $fields_not_in_post[] = $field_slug;
+            }
+        }
+    
     }
 
-    if ( !current_user_can( 'edit_user', $user_id ) ) {
-        return;
-    }
-
-    update_user_meta( $user_id, 'scud_user_title', $_POST['scud_user_title'] );
-    }
-}
+}   

--- a/class.scud-user-role.php
+++ b/class.scud-user-role.php
@@ -43,7 +43,7 @@ class Scud_User {
 
         // Save custom meta field values on profile update
         add_action( 'personal_options_update', array( $this, 'save_user_profile_fields' ) );
-        add_action( 'edit_user_profile_update', array( $this, 'scud_save_user_profile_fields' ) );
+        add_action( 'edit_user_profile_update', array( $this, 'save_user_profile_fields' ) );
 
     }
 
@@ -79,7 +79,7 @@ class Scud_User {
      * @param string $user_id The ID of the user being saved
      * @return void;
      */
-    public function save_user_profile_fields( $user_id ) {
+    public function save_user_profile_fields( string $user_id ): void {
     if ( empty( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'update-user_' . $user_id ) ) {
         return;
     }
@@ -88,6 +88,6 @@ class Scud_User {
         return;
     }
 
-    update_user_meta( $user_id, 'title', $_POST['title'] );
+    update_user_meta( $user_id, 'scud_user_title', $_POST['scud_user_title'] );
     }
 }

--- a/class.scud-user-role.php
+++ b/class.scud-user-role.php
@@ -2,13 +2,20 @@
 /**
 * Create a new user role with custom meta and taxonomy
 */
-class Scud_User_Role {
+class Scud_User {
 
     // A string with no spaces to act as a slug or internal reference to the role tupe
     private string $role_slug = 'simple_user';
 
     // A string which is displayed to admin screens
     private string $role_display_name = 'Simple User';
+
+     // WordPress Capabilities are listed here: https://wordpress.org/documentation/article/roles-and-capabilities/#capabilities
+    private array $capabilities = [
+        'read'         => true,
+        'edit_posts'   => true,
+        'delete_posts' => true,
+    ];
 
     /**
      * Register the custom user role
@@ -18,21 +25,8 @@ class Scud_User_Role {
      * @param none
      * @return void
      */
-    function scud_add_user_role(): void {
-        // A string with no spaces to act as a slug or internal reference to the role tupe
-        $role_slug = 'simple_user';
-
-        // A string which is displayed to admin screens
-        $role_display_name = 'Simple User';
-
-        // WordPress Capabilities are listed here: https://wordpress.org/documentation/article/roles-and-capabilities/#capabilities
-        $capabilities = [
-            'read'         => true,
-            'edit_posts'   => true,
-            'delete_posts' => true,
-        ];
-
-        add_role( $this->role_slug, $this->role_display_name, $capabilities );
+    public function add_user_role(): void {
+        add_role( $this->role_slug, $this->role_display_name, $this->capabilities );
     }
 
     // Add custom meta fields to the "edit user" admin screen

--- a/class.scud-user-role.php
+++ b/class.scud-user-role.php
@@ -25,6 +25,11 @@ class Scud_User {
     ];
 
     /**
+     * A string describing the group of meta fields assigned to this role
+     */
+    private string $meta_fields_heading = 'Additional Information';
+
+    /**
      * An array containing the slug and label for meta-data fields which should be saved to these types of user
      * The slug and label should be saved as key => value pairs:
      * [
@@ -82,7 +87,7 @@ class Scud_User {
         // For some reason, the action hooks expect the HTML code directly and won't render a string of HTML code
         // It would be cleaner to return the HTML string, but this type of templating works too
         ?>
-        <h3><?php _e('Additional information'); ?></h3>
+        <h3><?php echo $this->meta_fields_heading; ?></h3>
 
         <table class="form-table">
             <?php foreach ( $this->meta_fields as $field_slug => $field_label ):

--- a/class.scud-user-role.php
+++ b/class.scud-user-role.php
@@ -1,0 +1,89 @@
+<?php
+/**
+* Create a new user role with custom meta and taxonomy
+*/
+class Scud_User_Role {
+
+    // A string with no spaces to act as a slug or internal reference to the role tupe
+    private string $role_slug = 'simple_user';
+
+    // A string which is displayed to admin screens
+    private string $role_display_name = 'Simple User';
+
+    /**
+     * Register the custom user role
+     * Fires only on the activation hook, so the role is only registered once
+     *
+     * To read through the documentation on adding a custom user role, see https://developer.wordpress.org/reference/functions/add_role/
+     * @param none
+     * @return void
+     */
+    function scud_add_user_role(): void {
+        // A string with no spaces to act as a slug or internal reference to the role tupe
+        $role_slug = 'simple_user';
+
+        // A string which is displayed to admin screens
+        $role_display_name = 'Simple User';
+
+        // WordPress Capabilities are listed here: https://wordpress.org/documentation/article/roles-and-capabilities/#capabilities
+        $capabilities = [
+            'read'         => true,
+            'edit_posts'   => true,
+            'delete_posts' => true,
+        ];
+
+        add_role( $this->role_slug, $this->role_display_name, $capabilities );
+    }
+
+    // Add custom meta fields to the "edit user" admin screen
+    add_action( 'show_user_profile', 'scud_display_user_profile_fields' );
+    add_action( 'edit_user_profile', 'scud_display_user_profile_fields' );
+
+    /**
+     * Retrieve and display the user title field
+     *
+     * @param WP_User $user The user to show in the admin editor
+     * @return void The HTML code to disply the user field
+     */
+    function scud_display_user_profile_fields( WP_User $user ): void {
+        // Before we display the profile fields, retrieve the fields from the WP_User object
+        $saved_title = $user->get( 'scud_user_title' );
+
+        // For some reason, the action hooks expect the HTML code directly and won't render a string of HTML code
+        // It would be cleaner to return the HTML string, but this type of templating works too
+        ?>
+        <h3><?php _e('Additional information'); ?></h3>
+
+        <table class="form-table">
+            <tr>
+                <th><label for="scud_user_title"><?php _e( 'Title' ); ?></label></th>
+                <td>
+                    <input type="text" name="scud_user_title" id="scud_user_title" value="<?php echo esc_attr( $saved_title ); ?>" />
+                </td>
+            </tr>
+        </table>
+    <?php
+    }
+
+    // Save custom meta field values on profile update
+    add_action( 'personal_options_update', 'scud_save_user_profile_fields' );
+    add_action( 'edit_user_profile_update', 'scud_save_user_profile_fields' );
+
+    /**
+     * Save the user profile fields
+     *
+     * @param string $user_id The ID of the user being saved
+     * @return void;
+     */
+    function scud_save_user_profile_fields( $user_id ) {
+    if ( empty( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'update-user_' . $user_id ) ) {
+        return;
+    }
+
+    if ( !current_user_can( 'edit_user', $user_id ) ) {
+        return;
+    }
+
+    update_user_meta( $user_id, 'title', $_POST['title'] );
+    }
+}

--- a/class.scud-user-role.php
+++ b/class.scud-user-role.php
@@ -29,9 +29,23 @@ class Scud_User {
         add_role( $this->role_slug, $this->role_display_name, $this->capabilities );
     }
 
-    // Add custom meta fields to the "edit user" admin screen
-    add_action( 'show_user_profile', 'scud_display_user_profile_fields' );
-    add_action( 'edit_user_profile', 'scud_display_user_profile_fields' );
+    /**
+     * Run the action hooks when a user profile is loaded
+     *
+     * @param none;
+     * @return void;
+     */
+    public function user_profile_hooks(): void {
+
+        // Add custom meta fields to the "edit user" admin screen
+        add_action( 'show_user_profile', array( $this, 'display_user_profile_fields' ) );
+        add_action( 'edit_user_profile', array( $this, 'display_user_profile_fields' ) );
+
+        // Save custom meta field values on profile update
+        add_action( 'personal_options_update', array( $this, 'save_user_profile_fields' ) );
+        add_action( 'edit_user_profile_update', array( $this, 'scud_save_user_profile_fields' ) );
+
+    }
 
     /**
      * Retrieve and display the user title field
@@ -39,7 +53,7 @@ class Scud_User {
      * @param WP_User $user The user to show in the admin editor
      * @return void The HTML code to disply the user field
      */
-    function scud_display_user_profile_fields( WP_User $user ): void {
+    public function display_user_profile_fields( WP_User $user ): void {
         // Before we display the profile fields, retrieve the fields from the WP_User object
         $saved_title = $user->get( 'scud_user_title' );
 
@@ -59,17 +73,13 @@ class Scud_User {
     <?php
     }
 
-    // Save custom meta field values on profile update
-    add_action( 'personal_options_update', 'scud_save_user_profile_fields' );
-    add_action( 'edit_user_profile_update', 'scud_save_user_profile_fields' );
-
     /**
      * Save the user profile fields
      *
      * @param string $user_id The ID of the user being saved
      * @return void;
      */
-    function scud_save_user_profile_fields( $user_id ) {
+    public function save_user_profile_fields( $user_id ) {
     if ( empty( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'update-user_' . $user_id ) ) {
         return;
     }

--- a/class.scud-user-role.php
+++ b/class.scud-user-role.php
@@ -74,6 +74,11 @@ class Scud_User {
      */
     public function display_user_profile_fields( WP_User $user ): void {
 
+        // Avoid displaying the custom meta fields for other user roles
+        if ( ! in_array( $this->role_slug, $user->roles ) ) {
+            return;
+        }
+
         // For some reason, the action hooks expect the HTML code directly and won't render a string of HTML code
         // It would be cleaner to return the HTML string, but this type of templating works too
         ?>

--- a/class.scud-user-role.php
+++ b/class.scud-user-role.php
@@ -64,10 +64,12 @@ class Scud_User {
         // Add custom meta fields to the "edit user" admin screen
         add_action( 'show_user_profile', array( $this, 'display_user_profile_fields' ) );
         add_action( 'edit_user_profile', array( $this, 'display_user_profile_fields' ) );
+        add_action( 'user_new_form', array( $this, 'display_user_profile_fields' ) );
 
         // Save custom meta field values on profile update
         add_action( 'personal_options_update', array( $this, 'save_user_profile_fields' ) );
         add_action( 'edit_user_profile_update', array( $this, 'save_user_profile_fields' ) );
+        add_action( 'user_register', array( $this, 'save_user_profile_fields' ) );
 
     }
 

--- a/class.scud-user-role.php
+++ b/class.scud-user-role.php
@@ -4,13 +4,20 @@
 */
 class Scud_User {
 
-    // A string with no spaces to act as a slug or internal reference to the role tupe
+    /**
+     * A string with no spaces to act as a slug or internal reference to the role tupe
+     */
     private string $role_slug = 'simple_user';
 
-    // A string which is displayed to admin screens
+    /**
+     * A string which is displayed to admin screens
+     */
     private string $role_display_name = 'Simple User';
 
-     // WordPress Capabilities are listed here: https://wordpress.org/documentation/article/roles-and-capabilities/#capabilities
+    /**
+     * The capabilities that the user should have e.g. the ability to create posts or make theme changes
+     * WordPress Capabilities are listed here: https://wordpress.org/documentation/article/roles-and-capabilities/#capabilities
+     */
     private array $capabilities = [
         'read'         => true,
         'edit_posts'   => true,

--- a/simple-custom-user-display.php
+++ b/simple-custom-user-display.php
@@ -14,7 +14,9 @@ Domain Path: /languages
 
 defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
 
-define( 'SCUD_PLUGIN_PATH', plugin_dir_path( __FILE__ ));
+define( 'SCUD_PLUGIN_DIR', plugin_dir_path( __FILE__ ));
+
+require_once SCUD_PLUGIN_DIR . 'class.scud-user-role.php';
 
 // Register the new User Role
 register_activation_hook( __FILE__, 'scud_activation' );

--- a/simple-custom-user-display.php
+++ b/simple-custom-user-display.php
@@ -17,81 +17,17 @@ defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
 define( 'SCUD_PLUGIN_PATH', plugin_dir_path( __FILE__ ));
 
 // Register the new User Role
-register_activation_hook( __FILE__, 'scud_add_user_role' );
+register_activation_hook( __FILE__, 'scud_activation' );
 
 /**
- * Register the custom user role
- * Fires only on the activation hook, so the role is only registered once
+ * Execute set up tasks on plugin activation
  *
- * To read through the documentation on adding a custom user role, see https://developer.wordpress.org/reference/functions/add_role/
- * @param none
- * @return void
- */
-function scud_add_user_role(): void {
-    // A string with no spaces to act as a slug or internal reference to the role tupe
-    $role_slug = 'simple_user';
-
-    // A string which is displayed to admin screens
-    $role_display_name = 'Simple User';
-
-    // WordPress Capabilities are listed here: https://wordpress.org/documentation/article/roles-and-capabilities/#capabilities
-    $capabilities = [
-        'read'         => true,
-        'edit_posts'   => true,
-        'delete_posts' => true,
-    ];
-
-    add_role( $role_slug, $role_display_name, $capabilities );
-}
-
-// Add custom meta fields to the "edit user" admin screen
-add_action( 'show_user_profile', 'scud_display_user_profile_fields' );
-add_action( 'edit_user_profile', 'scud_display_user_profile_fields' );
-
-/**
- * Retrieve and display the user title field
- *
- * @param WP_User $user The user to show in the admin editor
- * @return void The HTML code to disply the user field
- */
-function scud_display_user_profile_fields( WP_User $user ): void {
-    // Before we display the profile fields, retrieve the fields from the WP_User object
-    $saved_title = $user->get( 'scud_user_title' );
-
-    // For some reason, the action hooks expect the HTML code directly and won't render a string of HTML code
-    // It would be cleaner to return the HTML string, but this type of templating works too
-    ?>
-    <h3><?php _e('Additional information'); ?></h3>
-
-    <table class="form-table">
-        <tr>
-            <th><label for="scud_user_title"><?php _e( 'Title' ); ?></label></th>
-            <td>
-                <input type="text" name="scud_user_title" id="scud_user_title" value="<?php echo esc_attr( $saved_title ); ?>" />
-            </td>
-        </tr>
-    </table>
-  <?php
-}
-
-// Save custom meta field values on profile update
-add_action( 'personal_options_update', 'scud_save_user_profile_fields' );
-add_action( 'edit_user_profile_update', 'scud_save_user_profile_fields' );
-
-/**
- * Save the user profile fields
- *
- * @param string $user_id The ID of the user being saved
+ * @param none;
  * @return void;
  */
-function scud_save_user_profile_fields( $user_id ) {
-  if ( empty( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'update-user_' . $user_id ) ) {
-    return;
-  }
+function scud_activation(): void {
 
-  if ( !current_user_can( 'edit_user', $user_id ) ) {
-    return;
-  }
-
-  update_user_meta( $user_id, 'title', $_POST['title'] );
+    // Add the new user role
+    $user_role = new Scud_User_Role();
+    $user_role->scud_add_user_role();
 }

--- a/simple-custom-user-display.php
+++ b/simple-custom-user-display.php
@@ -24,9 +24,9 @@ register_activation_hook( __FILE__, 'scud_add_user_role' );
  * Fires only on the activation hook, so the role is only registered once
  */
 function scud_add_user_role() {
-    $role_slug = 'sales_rep';
+    $role_slug = 'simple_user';
 
-    $role_display_name = 'Sales Representative';
+    $role_display_name = 'Simple User';
 
     $capabilities = [
         'read'         => true,

--- a/simple-custom-user-display.php
+++ b/simple-custom-user-display.php
@@ -35,7 +35,7 @@ function scud_activation(): void {
 }
 
 // Initialize custom user profile fields and meta
-add_action( 'admin_init', 'scud_load_user_role_meta' );
+add_action( 'current_screen', 'scud_load_user_role_meta' );
 
 /**
  * Conditionally load user meta fields based on the screen

--- a/simple-custom-user-display.php
+++ b/simple-custom-user-display.php
@@ -30,6 +30,6 @@ register_activation_hook( __FILE__, 'scud_activation' );
 function scud_activation(): void {
 
     // Add the new user role
-    $user_role = new Scud_User_Role();
-    $user_role->scud_add_user_role();
+    $scud_user = new Scud_User();
+    $scud_user->add_user_role();
 }

--- a/simple-custom-user-display.php
+++ b/simple-custom-user-display.php
@@ -15,3 +15,24 @@ Domain Path: /languages
 defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
 
 define( 'SCUD_PLUGIN_PATH', plugin_dir_path( __FILE__ ));
+
+// Register the new User Role
+register_activation_hook( __FILE__, 'scud_add_user_role' );
+
+/**
+ * Register the custom user role
+ * Fires only on the activation hook, so the role is only registered once
+ */
+function scud_add_user_role() {
+    $role_slug = 'sales_rep';
+
+    $role_display_name = 'Sales Representative';
+
+    $capabilities = [
+        'read'         => true,
+        'edit_posts'   => true,
+        'delete_posts' => true,
+    ];
+
+    add_role( $role_slug, $role_display_name, $capabilities );
+}

--- a/simple-custom-user-display.php
+++ b/simple-custom-user-display.php
@@ -43,3 +43,33 @@ function scud_add_user_role() {
 
     add_role( $role_slug, $role_display_name, $capabilities );
 }
+
+// Add custom meta fields to the "edit user" admin screen
+add_action( 'show_user_profile', 'scud_display_user_profile_fields' );
+add_action( 'edit_user_profile', 'scud_display_user_profile_fields' );
+
+/**
+ * Retrieve and display the user title field
+ *
+ * @param WP_User $user The user to show in the admin editor
+ * @return string The HTML code to disply the user field
+ */
+function scud_display_user_profile_fields( WP_User $user ) {
+    // Before we display the profile fields, retrieve the fields from the WP_User object
+    $saved_title = $user->get( 'scud_user_title' );
+
+    // Create the HTML string
+    // Heredoc would be preferred here, but I am not sure it works with translation functions
+    $html = '<h3>' . _e( 'Additional information' ) . '</h3>'
+        . '<table class="form-table">'
+            . '<tr>'
+                . '<th><label for="scud_user_title">' . _e( 'Title' ) . '</label></th>'
+                . '<td>'
+                    . '<input type="text" name="scud_user_title" id="scud_user_title" value="' . esc_attr( $saved_title ) . '" />'
+                . '</td>'
+            . '</tr>'
+        . '</table>';
+
+    // Return the HTML code
+    return $html;
+}

--- a/simple-custom-user-display.php
+++ b/simple-custom-user-display.php
@@ -33,3 +33,32 @@ function scud_activation(): void {
     $scud_user = new Scud_User();
     $scud_user->add_user_role();
 }
+
+// Initialize custom user profile fields and meta
+add_action( 'admin_init', 'scud_load_user_role_meta' );
+
+/**
+ * Conditionally load user meta fields based on the screen
+ *
+ * @param none;
+ * @return void;
+ */
+function scud_load_user_role_meta(): void {
+    $scud_user = new Scud_User();
+    $screen = get_current_screen();
+
+    if ( ! $screen ) {
+        return;
+    }
+
+    switch ( $screen->id ) {
+        case 'users':
+        case 'user':
+        case 'profile':
+        case 'user-edit':
+            $scud_user->user_profile_hooks();
+            break;
+        default:
+            break;
+        }
+}

--- a/simple-custom-user-display.php
+++ b/simple-custom-user-display.php
@@ -73,3 +73,25 @@ function scud_display_user_profile_fields( WP_User $user ): void {
     </table>
   <?php
 }
+
+// Save custom meta field values on profile update
+add_action( 'personal_options_update', 'scud_save_user_profile_fields' );
+add_action( 'edit_user_profile_update', 'scud_save_user_profile_fields' );
+
+/**
+ * Save the user profile fields
+ *
+ * @param string $user_id The ID of the user being saved
+ * @return void;
+ */
+function scud_save_user_profile_fields( $user_id ) {
+  if ( empty( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'update-user_' . $user_id ) ) {
+    return;
+  }
+
+  if ( !current_user_can( 'edit_user', $user_id ) ) {
+    return;
+  }
+
+  update_user_meta( $user_id, 'title', $_POST['title'] );
+}

--- a/simple-custom-user-display.php
+++ b/simple-custom-user-display.php
@@ -65,7 +65,7 @@ function scud_display_user_profile_fields( WP_User $user ) {
             . '<tr>'
                 . '<th><label for="scud_user_title">' . _e( 'Title' ) . '</label></th>'
                 . '<td>'
-                    . '<input type="text" name="scud_user_title" id="scud_user_title" value="' . esc_attr( $saved_title ) . '" />'
+                    . '<input type="text" name="scud_user_title" id="scud_user_title" value="' . esc_attr( $saved_title )  ?? '' . '" />'
                 . '</td>'
             . '</tr>'
         . '</table>';

--- a/simple-custom-user-display.php
+++ b/simple-custom-user-display.php
@@ -58,18 +58,18 @@ function scud_display_user_profile_fields( WP_User $user ): void {
     // Before we display the profile fields, retrieve the fields from the WP_User object
     $saved_title = $user->get( 'scud_user_title' );
 
-    // Create the HTML string
-    // Heredoc would be preferred here, but I am not sure it works with translation functions
-    $html = '<h3>' . _e( 'Additional information' ) . '</h3>'
-        . '<table class="form-table">'
-            . '<tr>'
-                . '<th><label for="scud_user_title">' . _e( 'Title' ) . '</label></th>'
-                . '<td>'
-                    . '<input type="text" name="scud_user_title" id="scud_user_title" value="' . esc_attr( $saved_title )  ?? '' . '" />'
-                . '</td>'
-            . '</tr>'
-        . '</table>';
+    // For some reason, the action hooks expect the HTML code directly and won't render a string of HTML code
+    // It would be cleaner to return the HTML string, but this type of templating works too
+    ?>
+    <h3><?php _e('Additional information'); ?></h3>
 
-    // Return the HTML code
-    return $html;
+    <table class="form-table">
+        <tr>
+            <th><label for="scud_user_title"><?php _e( 'Title' ); ?></label></th>
+            <td>
+                <input type="text" name="scud_user_title" id="scud_user_title" value="<?php echo esc_attr( $saved_title ); ?>" />
+            </td>
+        </tr>
+    </table>
+  <?php
 }

--- a/simple-custom-user-display.php
+++ b/simple-custom-user-display.php
@@ -27,7 +27,7 @@ register_activation_hook( __FILE__, 'scud_add_user_role' );
  * @param none
  * @return void
  */
-function scud_add_user_role() {
+function scud_add_user_role(): void {
     // A string with no spaces to act as a slug or internal reference to the role tupe
     $role_slug = 'simple_user';
 
@@ -52,9 +52,9 @@ add_action( 'edit_user_profile', 'scud_display_user_profile_fields' );
  * Retrieve and display the user title field
  *
  * @param WP_User $user The user to show in the admin editor
- * @return string The HTML code to disply the user field
+ * @return void The HTML code to disply the user field
  */
-function scud_display_user_profile_fields( WP_User $user ) {
+function scud_display_user_profile_fields( WP_User $user ): void {
     // Before we display the profile fields, retrieve the fields from the WP_User object
     $saved_title = $user->get( 'scud_user_title' );
 

--- a/simple-custom-user-display.php
+++ b/simple-custom-user-display.php
@@ -22,12 +22,19 @@ register_activation_hook( __FILE__, 'scud_add_user_role' );
 /**
  * Register the custom user role
  * Fires only on the activation hook, so the role is only registered once
+ *
+ * To read through the documentation on adding a custom user role, see https://developer.wordpress.org/reference/functions/add_role/
+ * @param none
+ * @return void
  */
 function scud_add_user_role() {
+    // A string with no spaces to act as a slug or internal reference to the role tupe
     $role_slug = 'simple_user';
 
+    // A string which is displayed to admin screens
     $role_display_name = 'Simple User';
 
+    // WordPress Capabilities are listed here: https://wordpress.org/documentation/article/roles-and-capabilities/#capabilities
     $capabilities = [
         'read'         => true,
         'edit_posts'   => true,


### PR DESCRIPTION
The first step in creating groups of users is to create a custom user role. 

This PR introduces the class `Scud_User`. The class has four major components:
- The ability to define a user role slug, label, and capabilities
- The function to add the user role on plugin activation
- A property to create meta fields in `slug => label` pairs
- Methods to display and save the meta fields

![screencapture-localhost-user-plugin-wp-admin-user-edit-php-2025-06-16-20_11_15](https://github.com/user-attachments/assets/6ef78748-b3cc-40c0-ba70-d8c56e7b9478)

## Testing Instructions
- Download the plugin files from this branch
- Install in wp-content/plugins
- Activate the plugin
- Add a new user, select the `Scud User` as the role
- Check that you can use the `slug_1` and `slug_2` meta fields 
- Create the user
- Click on the admin user profile to edit it
- Make sure you can still see the `slug_1` and `slug_2` meta fields 
- Check that the meta data you saved originally loads on the edit user page
