### PR TITLE
Group custom users by taxonomy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@
 /wp-includes/
 /index.php
 /license.txt
-/readme.html
 /wp-*.php
 /xmlrpc.php
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@ You can read more about the context here: https://jessboctor.com/2025/06/12/maki
 
 ## What this plugin is not:
 - A WYSIWYG editor for creating new user roles or custom display layouts
+- A fully translation ready plugin (sorry, my use case doesn't need it!)
 
 # The to-do list
 - [x] Create custom user roles
 - [x] Create custom user profile fields
 - [x] Make it possible to save the user metadata
-- [ ] Create custom user taxonomies
+- [x] Create custom user taxonomies
 - [ ] Query the user tables for the group member data
 - [ ] Display the user information in a DataView list
 - [ ] Make certain metadata available to be filterable within the DataView list

--- a/class.scud-user-group.php
+++ b/class.scud-user-group.php
@@ -16,7 +16,7 @@ if ( ! class_exists( 'Scud_Groups' ) ) {
          *
          * All available taxonomy parameters can be found here: https://developer.wordpress.org/reference/functions/register_taxonomy/
          */
-        public function register_taxonomies() {
+        public static function register_taxonomies() {
 
             // Group 1
             register_taxonomy(
@@ -67,7 +67,7 @@ if ( ! class_exists( 'Scud_Groups' ) ) {
          * @param none
          * @return void
          */
-        public function add_user_groups_to_menu(): void {
+        public static function add_user_groups_to_menu(): void {
             add_submenu_page( 'users.php', 'User Group One', 'First User Groups', 'edit_users', 'edit-tags.php?taxonomy=group_1' );
             add_submenu_page( 'users.php', 'User Group Two', 'Second User Groups', 'edit_users', 'edit-tags.php?taxonomy=group_2' );
         }

--- a/class.scud-user-group.php
+++ b/class.scud-user-group.php
@@ -1,6 +1,9 @@
 <?php
 namespace SCUD;
 
+use Scud_User;
+use WP_User;
+
 /**
  * Create new user taxonomies
  */
@@ -91,8 +94,58 @@ if ( ! class_exists( 'Scud_Groups' ) ) {
 
         /**
          * Display the taxonomy fields on user profiles
+         *
+         * @param WP_User $user The user to show in the admin editor
+         * @return void The HTML code to disply the user field gets passed to the profile
          */
-        public function display_user_taxonomy_fields(): void {}
+        public function display_user_taxonomy_fields( WP_User $user ): void {
+            // Return early if the current user does not have the abiility to edit other users
+            if ( ! current_user_can( 'edit_users' ) ) {
+                return;
+            }
+
+            // Avoid displaying the custom taxonomy fields for other user roles
+            $scud_user = new Scud_User();
+            if ( ! in_array( $scud_user->role_slug, $user->roles ) ) {
+                return;
+            }
+			?>
+            <h3><?php esc_html_e( 'User Groups' ); ?></h3>
+            <div class="user-taxonomy-wrapper">
+				<?php
+				wp_nonce_field( 'user-groups', 'user-groups' );
+
+				$user_taxonomies = get_object_taxonomies( 'user', 'objects' );
+                if ( ! empty( $user_taxonomies ) ) :
+				    foreach ( $user_taxonomies as $taxonomy ) {
+                    ?>
+                        <table class="form-table user-profile-taxonomy">
+                            <tr>
+                                <th>
+                                    <label for="new-tag-user_tag_<?php echo esc_attr( $taxonomy->name ); ?>">
+										<?php echo esc_html( $taxonomy->labels->singular_name ); ?>
+                                    </label>
+                                </th>
+                                <td>
+									<?php
+									wp_terms_checklist(
+										$user->ID,
+										array(
+											'taxonomy' => $taxonomy->name,
+											'walker'   => 'Walker_Category_Checklist',
+										)
+									);
+									?>
+                                </td>
+                            </tr>
+                        </table>
+					<?php
+				    } // Taxonomies
+                endif; // Taxonomies exist
+				?>
+            </div>
+			<?php
+        }
 
         /**
          * Update terms saved to a user on profile update

--- a/class.scud-user-group.php
+++ b/class.scud-user-group.php
@@ -83,10 +83,12 @@ if ( ! class_exists( 'Scud_Groups' ) ) {
             // Show on User Profiles.
             add_action( 'show_user_profile', array( $this, 'display_user_taxonomy_fields' ) );
             add_action( 'edit_user_profile', array( $this, 'display_user_taxonomy_fields' ) );
+            add_action( 'user_new_form', array( $this, 'display_user_taxonomy_fields' ) );
 
             // Update on Save
             add_action( 'personal_options_update', array( $this, 'save_user_taxonomy_terms' ) );
             add_action( 'edit_user_profile_update', array( $this, 'save_user_taxonomy_terms' ) );
+            add_action( 'user_register', array( $this, 'save_user_taxonomy_terms' ) );
 
             // Clear up related tags and taxonomies, when a user is deleted.
             add_action( 'deleted_user', array( $this, 'update_user_assigned_to_terms' ) );

--- a/class.scud-user-group.php
+++ b/class.scud-user-group.php
@@ -13,7 +13,7 @@ if ( ! class_exists( 'Scud_Groups' ) ) {
          *
          * All available taxonomy parameters can be found here: https://developer.wordpress.org/reference/functions/register_taxonomy/
          */
-        public static function register_taxonomies() {
+        public function register_taxonomies() {
 
             // Group 1
             register_taxonomy(

--- a/class.scud-user-group.php
+++ b/class.scud-user-group.php
@@ -1,0 +1,59 @@
+<?php
+namespace SCUD;
+
+/**
+ * Create new user taxonomies
+ */
+if ( ! class_exists( 'Scud_Groups' ) ) {
+    class Scud_Groups {
+        /**
+         * There's no clean way to store taxonomy information without just registering it.
+         * Let's avoid complexity and just hard code the taxonomy features during registration,
+         *   rather than trying to pull the information from somewhere else.
+         *
+         * All available taxonomy parameters can be found here: https://developer.wordpress.org/reference/functions/register_taxonomy/
+         */
+        public static function register_taxonomies() {
+
+            // Group 1
+            register_taxonomy(
+                'group_1',
+                'user',
+                array(
+                    'public' => true,
+                    'show_ui' => true,
+                    'labels' => array(
+                        'name' => 'First User Groups',
+                        'singular_name' => 'User Group 1'
+                    ),
+                    'capabilities' => array(
+                        'manage_terms' => 'edit_users',
+                        'edit_terms'  => 'edit_users',
+                        'delete_terms' => 'edit_users',
+                        'assign_terms' => 'edit_users',
+                    ),
+                )
+            );
+
+            // Group 2
+            register_taxonomy(
+                'group_2',
+                'user',
+                array(
+                    'public' => true,
+                    'show_ui' => true,
+                    'labels' => array(
+                        'name' => 'Second User Groups',
+                        'singular_name' => 'User Group 2'
+                    ),
+                    'capabilities' => array(
+                        'manage_terms' => 'edit_users',
+                        'edit_terms'  => 'edit_users',
+                        'delete_terms' => 'edit_users',
+                        'assign_terms' => 'edit_users',
+                    ),
+                )
+            );
+        }
+    }
+}

--- a/class.scud-user-group.php
+++ b/class.scud-user-group.php
@@ -74,15 +74,15 @@ if ( ! class_exists( 'Scud_Groups' ) ) {
          */
         public function user_profile_hooks() {
             // Show on User Profiles.
-            add_action( 'show_user_profile', array( $this, 'user_profile' ) );
-            add_action( 'edit_user_profile', array( $this, 'user_profile' ) );
+            add_action( 'show_user_profile', array( $this, 'display_user_taxonomy_fields' ) );
+            add_action( 'edit_user_profile', array( $this, 'display_user_taxonomy_fields' ) );
 
             // Update on Save
-            add_action( 'personal_options_update', array( $this, 'save_taxonomy_terms' ) );
-            add_action( 'edit_user_profile_update', array( $this, 'save_taxonomy_terms' ) );
+            add_action( 'personal_options_update', array( $this, 'save_user_taxonomy_terms' ) );
+            add_action( 'edit_user_profile_update', array( $this, 'save_user_taxonomy_terms' ) );
 
             // Clear up related tags and taxonomies, when a user is deleted.
-            add_action( 'deleted_user', array( $this, 'update_user_list' ) );
+            add_action( 'deleted_user', array( $this, 'update_user_assigned_to_terms' ) );
         }
     }
 }

--- a/class.scud-user-group.php
+++ b/class.scud-user-group.php
@@ -55,5 +55,18 @@ if ( ! class_exists( 'Scud_Groups' ) ) {
                 )
             );
         }
+
+        /**
+         * Add a menu screen for each taxonomy
+         * This allows you to manage terms
+         * You need to create on new menu (e.g. call add_submenu_page) for each taxonomy which is registered
+         *
+         * @param none
+         * @return void
+         */
+        public function add_user_groups_to_menu(): void {
+            add_submenu_page( 'users.php', 'User Group One', 'First User Groups', 'edit_users', 'edit-tags.php?taxonomy=group_1' );
+            add_submenu_page( 'users.php', 'User Group Two', 'Second User Groups', 'edit_users', 'edit-tags.php?taxonomy=group_2' );
+        }
     }
 }

--- a/class.scud-user-group.php
+++ b/class.scud-user-group.php
@@ -88,5 +88,24 @@ if ( ! class_exists( 'Scud_Groups' ) ) {
             // Clear up related tags and taxonomies, when a user is deleted.
             add_action( 'deleted_user', array( $this, 'update_user_assigned_to_terms' ) );
         }
+
+        /**
+         * Display the taxonomy fields on user profiles
+         */
+        public function display_user_taxonomy_fields(): void {}
+
+        /**
+         * Update terms saved to a user on profile update
+         */
+        public function save_user_taxonomy_terms(): void {
+            return;
+        }
+
+        /**
+         * Clear up related tags and taxonomies when a user is deleted
+         */
+        public function update_user_assigned_to_terms(): void {
+            return;
+        }
     }
 }

--- a/class.scud-user-group.php
+++ b/class.scud-user-group.php
@@ -69,6 +69,10 @@ if ( ! class_exists( 'Scud_Groups' ) ) {
             add_submenu_page( 'users.php', 'User Group Two', 'Second User Groups', 'edit_users', 'edit-tags.php?taxonomy=group_2' );
         }
 
+        // Deep thanks to Justin Tadlock and his user-tags plugin for this next bit
+        // https://wordpress.org/plugins/user-tags/
+        // https://justintadlock.com/archives/2011/10/20/custom-user-taxonomies-in-wordpress
+
         /**
          * Update user taxonomies in the profile page
          */

--- a/class.scud-user-group.php
+++ b/class.scud-user-group.php
@@ -68,5 +68,21 @@ if ( ! class_exists( 'Scud_Groups' ) ) {
             add_submenu_page( 'users.php', 'User Group One', 'First User Groups', 'edit_users', 'edit-tags.php?taxonomy=group_1' );
             add_submenu_page( 'users.php', 'User Group Two', 'Second User Groups', 'edit_users', 'edit-tags.php?taxonomy=group_2' );
         }
+
+        /**
+         * Update user taxonomies in the profile page
+         */
+        public function user_profile_hooks() {
+            // Show on User Profiles.
+            add_action( 'show_user_profile', array( $this, 'user_profile' ) );
+            add_action( 'edit_user_profile', array( $this, 'user_profile' ) );
+
+            // Update on Save
+            add_action( 'personal_options_update', array( $this, 'save_taxonomy_terms' ) );
+            add_action( 'edit_user_profile_update', array( $this, 'save_taxonomy_terms' ) );
+
+            // Clear up related tags and taxonomies, when a user is deleted.
+            add_action( 'deleted_user', array( $this, 'update_user_list' ) );
+        }
     }
 }

--- a/class.scud-user-group.php
+++ b/class.scud-user-group.php
@@ -1,7 +1,7 @@
 <?php
 namespace SCUD;
 
-use Scud_User;
+use SCUD\Scud_User;
 use WP_User;
 
 /**

--- a/class.scud-user-group.php
+++ b/class.scud-user-group.php
@@ -151,9 +151,35 @@ if ( ! class_exists( 'Scud_Groups' ) ) {
 
         /**
          * Update terms saved to a user on profile update
+         *
+         * @param string $user_id The ID of the user being saved
+         * @return void;
          */
-        public function save_user_taxonomy_terms(): void {
-            return;
+        public function save_user_taxonomy_terms( string $user_id ): void {
+            // Check this save is being called from the correct admin screen and nonce
+            check_admin_referer( 'update-user_' . $user_id );
+
+			// Check if the current user can edit this user.
+			if ( empty( $_POST['tax_input'] ) || ! current_user_can( 'edit_user', $user_id ) ) {
+				return;
+			}
+
+			//phpcs:ignore
+			$input_tags = wp_unslash( $_POST['tax_input'] );
+            // The structure of the taxonomy data here is taxonomy_slug => array of terms
+			foreach ( $input_tags as $taxonomy => $taxonomy_terms ) {
+
+				$taxonomy       = sanitize_key( $taxonomy );
+				$taxonomy_terms = array_map( 'absint', $taxonomy_terms );
+
+				// Save the data.
+				if ( ! empty( $taxonomy_terms ) ) :
+					wp_set_object_terms( $user_id, $taxonomy_terms, $taxonomy, false );
+				else :
+					// No terms left, delete all terms.
+					wp_set_object_terms( $user_id, array(), $taxonomy, false );
+				endif;
+			}
         }
 
         /**

--- a/class.scud-user-group.php
+++ b/class.scud-user-group.php
@@ -91,7 +91,7 @@ if ( ! class_exists( 'Scud_Groups' ) ) {
             add_action( 'user_register', array( $this, 'save_user_taxonomy_terms' ) );
 
             // Clear up related tags and taxonomies, when a user is deleted.
-            add_action( 'deleted_user', array( $this, 'update_user_assigned_to_terms' ) );
+            add_action( 'deleted_user', array( $this, 'remove_user_from_terms_list' ) );
         }
 
         /**
@@ -184,9 +184,20 @@ if ( ! class_exists( 'Scud_Groups' ) ) {
 
         /**
          * Clear up related tags and taxonomies when a user is deleted
+         *
+         * @param string $user_id The id of the user being deleted
+         * @return void
          */
-        public function update_user_assigned_to_terms(): void {
-            return;
+        public function remove_user_from_terms_list( string $user_id ): void {
+            $taxonomies    = get_object_taxonomies( 'user', 'object' );
+			$taxonomy_list = array();
+			foreach ( $taxonomies as $key => $taxonomy ) {
+				$taxonomy_list[] = $key;
+			}
+			// Delete the relation for a user.
+			if ( ! empty( $taxonomy_list ) && is_array( $taxonomy_list ) ) {
+				wp_delete_object_term_relationships( $user_id, $taxonomy_list );
+			}
         }
     }
 }

--- a/simple-custom-user-display.php
+++ b/simple-custom-user-display.php
@@ -42,7 +42,11 @@ function scud_activation(): void {
 add_action( 'current_screen', 'scud_load_user' );
 
 /**
- * Conditionally load user meta fields based on the screen
+ * Conditionally load user fields based on the screen
+ *
+ * We need to load two sets of fields
+ * - Meta Data
+ * - Taxonomies
  *
  * @param none;
  * @return void;
@@ -50,6 +54,7 @@ add_action( 'current_screen', 'scud_load_user' );
 function scud_load_user(): void {
 
     $scud_user = new Scud_User();
+    $scud_groups = new Scud_Groups();
     $screen = get_current_screen();
 
     if ( ! $screen ) {
@@ -62,6 +67,7 @@ function scud_load_user(): void {
         case 'profile':
         case 'user-edit':
             $scud_user->user_profile_hooks();
+            $scud_groups->user_profile_hooks();
             break;
         default:
             break;

--- a/simple-custom-user-display.php
+++ b/simple-custom-user-display.php
@@ -13,12 +13,14 @@ Domain Path: /languages
 */
 
 use SCUD\Scud_User;
+use SCUD\Scud_Groups;
 
 defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
 
 define( 'SCUD_PLUGIN_DIR', plugin_dir_path( __FILE__ ));
 
 require_once SCUD_PLUGIN_DIR . 'class.scud-user-role.php';
+require_once SCUD_PLUGIN_DIR . 'class.scud-user-group.php';
 
 // Register the new User Role
 register_activation_hook( __FILE__, 'scud_activation' );
@@ -64,4 +66,18 @@ function scud_load_user(): void {
         default:
             break;
         }
+}
+
+// Register & Load the new user group taxonomies
+add_action( 'init', 'scud_load_user_groups' );
+
+// Load the taxonomies in the admin menu
+function scud_load_user_groups() {
+    $scud_groups = new Scud_Groups();
+
+    // Register taxonomies
+    $scud_groups->register_taxonomies();
+
+    // Load admin screens
+    $scud_groups->add_user_groups_to_menu();
 }

--- a/simple-custom-user-display.php
+++ b/simple-custom-user-display.php
@@ -79,11 +79,9 @@ add_action( 'init', 'scud_load_user_groups' );
 
 // Load the taxonomies in the admin menu
 function scud_load_user_groups() {
-    $scud_groups = new Scud_Groups();
-
     // Register taxonomies
-    $scud_groups->register_taxonomies();
+    Scud_Groups::register_taxonomies();
 
     // Load admin screens
-    $scud_groups->add_user_groups_to_menu();
+    Scud_Groups::add_user_groups_to_menu();
 }


### PR DESCRIPTION
This PR introduces the ability to group users which have the custom user role assigned to them.

There are four pieces of core functionality included:
- Registering the taxonomy
- Adding sub-menu pages to wp-admin for managing the taxonomy terms
- Showing and saving the taxonomy terms on a user profile page to assign/remove the terms from a user
- Deleting the relationship between a user ID and a term ID if the user is deleted.

**Admin Subpages**
<img width="345" alt="Screenshot 2025-06-18 at 12 31 16 PM" src="https://github.com/user-attachments/assets/cdb6ff84-8d09-4471-bc2f-3418061ff6b2" />

**Taxonomy Edit Page**
<img width="1503" alt="Screenshot 2025-06-18 at 12 31 34 PM" src="https://github.com/user-attachments/assets/7a937795-524c-448d-b7f7-532039f5084d" />

**Taxonomy List on User Profile Page**
<img width="501" alt="Screenshot 2025-06-18 at 12 31 47 PM" src="https://github.com/user-attachments/assets/969913b0-93bd-4a20-a767-78a73b742f5a" />

## Testing Instructions
- Pull this PR
- Load the `Simple Custom User Display` plugin and make sure it is activated
- Go to Users and hover over the menu to make sure the "First User Groups" option is available
- Click on "First User Groups"
- Add or remove/edit taxonomy terms
- Click on a user
- Make sure they have the "Scud User" in the title of their profile page
- Scroll to the bottom of the profile page
- Make sure you can see the "First User Groups" terms in a list
- Check off some options, then save the profile
- When the profile loads, make sure the terms checked reflect the ones you selected
- Open a user that doesn't have the "Scud User" role assigned to it
- Scroll to the bottom of their profile page
- Make sure the taxonomies aren't listed